### PR TITLE
fix: naming incorrect dans la table suivi_diplomation

### DIFF
--- a/models/dashboards/diplome/pbi_tables/dip_report_suivi_diplomation.sql
+++ b/models/dashboards/diplome/pbi_tables/dip_report_suivi_diplomation.sql
@@ -19,7 +19,7 @@ with
     -- identifier le perimètre des élève de l'année en cours
     perim as (
         select fiche, ele.id_eco
-        from {{ ref("stg_perimetre_eleve_diplomation_des") }} as ele
+        from {{ ref("stg_perimetre_eleve_frequentation_des") }} as ele
         inner join
             {{ ref("dim_mapper_schools") }} as eco
             on ele.id_eco = eco.id_eco


### PR DESCRIPTION
Un changement de nom de table a été faite dans la PR de l'ajout du tdb PEVR.

Un oubli a été faite et la table suivi_diplomation appelle l'ancienne table.

Cette PR vise à régler ce Problème.